### PR TITLE
Sync generic-deriving internals with generic-deriving-1.14

### DIFF
--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -530,12 +530,10 @@ checkExistentialContext conName vars ctxt =
 -- TemplateHaskell language extension when compiling the generic-deriving library.
 -- This allows the library to be used in stage1 cross-compilers.
 
+-- NB: This is one of the few spots where we change the copy-pasted definition
+-- from generic-deriving slightly to avoid referencing the wrong package.
 gdPackageKey :: String
-#ifdef CURRENT_PACKAGE_KEY
 gdPackageKey = CURRENT_PACKAGE_KEY
-#else
-gdPackageKey = "generic-deriving-" ++ showVersion version
-#endif
 
 mkGD4'4_d :: String -> Name
 #if MIN_VERSION_base(4,6,0)


### PR DESCRIPTION
This has the knock-on effect of removing the CPP'ed definition of `TyVarBndr_`, as it is now imported from `th-abstraction` instead.