### PR TITLE
Add Generic generics

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -9,9 +9,10 @@ steps:
       style: vertical
       remove_redundant: true
   - trailing_whitespace: {}
-columns: 80
+columns: 120
 language_extensions:
   - EmptyCase
   - ExplicitForAll
   - FlexibleContexts
   - MultiParamTypeClasses
+  - TemplateHaskell

--- a/src/Staged/GHC/Generics/GHCish.hs
+++ b/src/Staged/GHC/Generics/GHCish.hs
@@ -1,0 +1,149 @@
+{-# language AllowAmbiguousTypes #-}
+{-# language DataKinds #-}
+{-# language EmptyCase #-}
+{-# language FlexibleContexts #-}
+{-# language FlexibleInstances #-}
+{-# language KindSignatures #-}
+{-# language PolyKinds #-}
+{-# language ScopedTypeVariables #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TemplateHaskellQuotes #-}
+{-# language TypeApplications #-}
+{-# language TypeFamilies #-}
+{-# language TypeOperators #-}
+
+module Staged.GHC.Generics.GHCish
+  ( ghcGenericTo
+  , ghcGenericFrom
+  ) where
+
+import Staged.GHC.Generics.Types
+import qualified GHC.Generics as G
+import Language.Haskell.TH.Syntax hiding (Type)
+import Language.Haskell.TH.Lib
+import Data.Kind (Type, Constraint)
+import Data.Bifunctor (first)
+
+-- A proxy type for GHC.Generics functions
+data Prox (d :: Meta) (f :: j -> Type) (a :: j) = Prox
+toProx :: forall j (q :: Type -> Type) i (d :: Meta) (f :: (Type -> Type) -> j -> Type) (a :: j).
+  M2 i d f q a -> Prox d (f q) a
+toProx _ = Prox
+
+-- | Use GHC generics to implement the 'to' method.
+ghcGenericTo :: (Rep a ~ Translate (G.Rep a), G.Generic a, GGeneric (Rep a), Quote q)
+  => Rep a (Code q) x -> Code q a
+ghcGenericTo = unsafeCodeCoerce . gto
+
+{-
+-- `from` is not the most obvious thing, in general. I found it quite
+-- helpful to look at an example of what we're trying to build.
+
+data MyType a = My1 a | My2 a a
+  deriving (G.Generic)
+
+instance Generic (MyType a) where
+  from x k = unsafeCodeCoerce $ caseE (unTypeCode x) [
+      do
+        v1 <- newName "v1"
+        match (conP 'My1 [varP v1])
+              (normalB $ unTypeCode $ k (M2 (L2 (M2 (M2 (K2 (unsafeCodeCoerce $ varE v1)))))))
+              []
+    , do
+        v1 <- newName "v1"
+        v2 <- newName "v2"
+        match (conP 'My2 [varP v1, varP v2])
+              (normalB $ unTypeCode $ k (M2 (R2 (M2
+                (M2 (K2 (unsafeCodeCoerce $ varE v1)) :**: M2 (K2 (unsafeCodeCoerce $ varE v2)))))))
+              []
+    ]
+-}
+
+-- | Use GHC generics to implement the 'from' method.
+ghcGenericFrom :: (Rep a ~ Translate (G.Rep a), G.Generic a, GGeneric (Rep a), Quote q)
+  => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
+ghcGenericFrom c k = unsafeCodeCoerce $ caseE (unTypeCode c) $ gmatches k
+
+class GGeneric (f :: (Type -> Type) -> Type -> Type) where
+  gto :: Quote q => f (Code q) x -> q Exp
+
+  -- Build the list of case branches.
+  gmatches :: Quote q => (f (Code q) x -> Code q r) -> [q Match]
+
+-- | Make a "namer" function holding on to a package and module name to
+-- eventually make a Name out of the bare constructor name
+mkNamer :: forall (d :: Meta). Datatype d => String -> Name
+mkNamer = mkNameG_d (packageName prox) (moduleName prox)
+  where
+    prox :: Prox d z w
+    prox = Prox
+
+instance (Datatype d, GGenericCon f) => GGeneric (D2 d f) where
+  gto (M2 fqp) = gtoCon (mkNamer @d) fqp
+  gmatches k = gmatchesCon (mkNamer @d) (k . M2) []
+
+class GGenericCon (f :: (Type -> Type) -> Type -> Type) where
+  gtoCon :: Quote q => (String -> Name) -> f (Code q) x -> q Exp
+  -- We take a "namer" function that holds on to the package and module names
+  -- for us so we can apply the constructor name and get its 'Name'.
+  gmatchesCon :: Quote q => (String -> Name) -> (f (Code q) x -> Code q r) -> [q Match] -> [q Match]
+
+instance GGenericCon V2 where
+  gtoCon _ x = case x of
+  gmatchesCon _ _ [] = []
+  gmatchesCon _ _ _ = error "V2 shouldn't lead to more constructors!"
+
+instance (GGenericCon f, GGenericCon g) => GGenericCon (f :++: g) where
+  gtoCon namer (L2 x) = gtoCon namer x
+  gtoCon namer (R2 x) = gtoCon namer x
+
+  gmatchesCon namer k = gmatchesCon @f namer (k . L2) . gmatchesCon @g namer (k . R2)
+
+type GNumFields :: forall {k}. ((Type -> Type) -> k -> Type) -> Constraint
+class GNumFields (f :: (Type -> Type) -> k -> Type) where
+  gnumFields :: Int
+instance (GNumFields f, GNumFields g) => GNumFields (f :**: g) where
+  gnumFields = gnumFields @f + gnumFields @g
+instance GNumFields U2 where
+  gnumFields = 0
+instance GNumFields (S2 c f) where
+  gnumFields = 1
+
+instance (Constructor c, GGenericFields f, GNumFields f) => GGenericCon (C2 c f) where
+  gtoCon namer m@(M2 fqp) = gtoFields (conE conN) fqp
+    where
+      conN :: Name
+      conN = namer (conName (toProx m))
+  gmatchesCon namer k rest = [do
+    let name_bases = ["v" ++ show n | n <- [1..gnumFields @f]]
+    names <- traverse newName name_bases
+    match (conP conN (map varP names)) (normalB . unTypeCode . k . M2 $ fst (grebuild names)) []
+    ] ++ rest
+    where
+      conN :: Name
+      conN = namer (conName (Prox @_ @c))
+
+class GGenericFields f where
+  gtoFields :: Quote q => q Exp -> f (Code q) x -> q Exp
+  grebuild :: Quote q => [Name] -> (f (Code q) x, [Name])
+
+instance GGenericFields f => GGenericFields (S2 c f) where
+  gtoFields c (M2 x) = gtoFields c x
+  grebuild = first M2 . grebuild
+
+instance GGenericFields U2 where
+  gtoFields c U2 = c
+  grebuild [] = (U2, [])
+  grebuild _ = error "oopsy"
+
+instance (GGenericFields f, GGenericFields g) => GGenericFields (f :**: g) where
+  gtoFields c (x :**: y) = gtoFields (gtoFields c x) y
+  grebuild v
+    | (l, v') <- grebuild v
+    , (r, v'') <- grebuild v'
+    = (l :**: r, v'')
+
+instance GGenericFields (K2 c) where
+  gtoFields c (K2 x) = [| $c $(unTypeCode x) |]
+  grebuild [] = error "Not enough names!"
+  grebuild (a : as) = (K2 (unsafeCodeCoerce (varE a)), as)

--- a/src/Staged/GHC/Generics/GHCish.hs
+++ b/src/Staged/GHC/Generics/GHCish.hs
@@ -130,11 +130,11 @@ instance (Constructor c, GGenericFields f, GMakeNames f) => GGenericCon (C2 c f)
     where
       conN :: Name
       conN = namer (conName (toProx m))
-  gmatchesCon namer k rest = [do
+  gmatchesCon namer k rest = (do
     (names, namesb', _) <- makeNames 0
     let names' = namesb' []
     match (conP conN (map varP names')) (normalB . unTypeCode . k . M2 $ grebuild names) []
-    ] ++ rest
+    ) : rest
     where
       conN :: Name
       conN = namer (conName (Prox @_ @c))

--- a/src/Staged/GHC/Generics/Generic.hs
+++ b/src/Staged/GHC/Generics/Generic.hs
@@ -13,10 +13,14 @@
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
 
-module Staged.GHC.Generics.GHCish
-  ( GGeneric (..)
-  , ghcGenericTo
-  , ghcGenericFrom
+-- | This module offers facilities for producing 'Staged.GHC.Generics.Generic'
+-- representations and methods based on the corresponding
+-- @"GHC.Generic".'GHC.Generics.Generic'@ ones.
+module Staged.GHC.Generics.Generic
+  ( GGeneric
+  , GRep
+  , genericTo
+  , genericFrom
   ) where
 
 import Control.Applicative        (liftA2)
@@ -37,15 +41,19 @@ toProx :: forall j (q :: Type -> Type) i (d :: Meta) (f :: (Type -> Type) -> j -
   M2 i d f q a -> Prox d (f q) a
 toProx _ = Prox
 
--- | Use GHC generics to implement the 'to' method.
-ghcGenericTo :: (GHC.Generic a, GGeneric (Translate (GHC.Rep a)), Quote q)
-  => Translate (GHC.Rep a) (Code q) x -> Code q a
-ghcGenericTo = unsafeCodeCoerce . gto
+-- | Use GHC generics to implement the 'Staged.GHC.Generics.Rep'
+-- associated type.
+type GRep a = Translate (GHC.Rep a)
 
--- | Use GHC generics to implement the 'from' method.
-ghcGenericFrom :: (GHC.Generic a, GGeneric (Translate (GHC.Rep a)), Quote q)
+-- | Use GHC generics to implement the 'Staged.GHC.Generics.to' method.
+genericTo :: (GHC.Generic a, GGeneric (Translate (GHC.Rep a)), Quote q)
+  => Translate (GHC.Rep a) (Code q) x -> Code q a
+genericTo = unsafeCodeCoerce . gto
+
+-- | Use GHC generics to implement the 'Staged.GHC.Generics.from' method.
+genericFrom :: (GHC.Generic a, GGeneric (Translate (GHC.Rep a)), Quote q)
   => Code q a -> (Translate (GHC.Rep a) (Code q) x -> Code q r) -> Code q r
-ghcGenericFrom c k = unsafeCodeCoerce $ caseE (unTypeCode c) $ gmatches k
+genericFrom c k = unsafeCodeCoerce $ caseE (unTypeCode c) $ gmatches k
 
 {-
 -- `from` is not the most obvious thing, in general. I found it quite
@@ -71,6 +79,8 @@ instance Generic (MyType a) where
     ]
 -}
 
+-- | A class for generic representations of types supporting
+-- staged generic operations.
 class GGeneric (f :: (Type -> Type) -> Type -> Type) where
   gto :: Quote q => f (Code q) x -> q Exp
 

--- a/src/Staged/GHC/Generics/Generic.hs
+++ b/src/Staged/GHC/Generics/Generic.hs
@@ -47,12 +47,12 @@ type GRep a = Translate (GHC.Rep a)
 
 -- | Use GHC generics to implement the 'Staged.GHC.Generics.to' method.
 genericTo :: (GHC.Generic a, GGeneric (Translate (GHC.Rep a)), Quote q)
-  => Translate (GHC.Rep a) (Code q) x -> Code q a
+  => GRep a (Code q) x -> Code q a
 genericTo = unsafeCodeCoerce . gto
 
 -- | Use GHC generics to implement the 'Staged.GHC.Generics.from' method.
 genericFrom :: (GHC.Generic a, GGeneric (Translate (GHC.Rep a)), Quote q)
-  => Code q a -> (Translate (GHC.Rep a) (Code q) x -> Code q r) -> Code q r
+  => Code q a -> (GRep a (Code q) x -> Code q r) -> Code q r
 genericFrom c k = unsafeCodeCoerce $ caseE (unTypeCode c) $ gmatches k
 
 {-

--- a/src/Staged/GHC/Generics/Instances.hs
+++ b/src/Staged/GHC/Generics/Instances.hs
@@ -59,6 +59,10 @@ import Text.Read.Lex
 -- there is manual instance for this
 -- deriveGeneric ''Bool
 
+-- Caution! While [a] may seem like a good type to use as an example for a
+-- mostly-hand-written or GHC.Generic-derived instance, it should not be used
+-- so (at least as of GHC 9.2.1). GHC's Rep/Rep1 produce incorrect metadata for
+-- the (:) constructor. See GHC Gitlab issue #20994.
 deriveGeneric ''[]
 deriveGeneric ''Ordering
 deriveGeneric ''Maybe

--- a/src/Staged/GHC/Generics/RepTypes.hs
+++ b/src/Staged/GHC/Generics/RepTypes.hs
@@ -53,21 +53,21 @@ import GHC.TypeLits        (ErrorMessage (..), TypeError)
 -- Combinators
 -------------------------------------------------------------------------------
 
-data V2 (q :: z) (p :: k)
+data V2 (q :: Type -> Type) (p :: k)
 
 deriving instance Eq (V2 q p)
 deriving instance Ord (V2 q p)
 deriving instance Show (V2 q p)
 deriving instance Read (V2 q p)
 
-data U2 (q :: z) (p :: k) = U2
+data U2 (q :: Type -> Type) (p :: k) = U2
 
 deriving instance Eq (U2 q p)
 deriving instance Ord (U2 q p)
 deriving instance Show (U2 q p)
 deriving instance Read (U2 q p)
 
-newtype M2 (i :: Type) (c :: Meta) (f :: z -> k -> Type) (q :: z) (p :: k)
+newtype M2 (i :: Type) (c :: Meta) (f :: (Type -> Type) -> k -> Type) (q :: Type -> Type) (p :: k)
     = M2 { unM2 :: f q p }
 
 deriving instance Eq (f q p) => Eq (M2 i c f q p)
@@ -84,7 +84,7 @@ deriving instance Show (q c) => Show (K2 c q p)
 deriving instance Read (q c) => Read (K2 c q p)
 
 infixr 5 :++:
-data ((f :: z -> k -> Type) :++: (g :: z -> k -> Type)) (q :: z) (p :: k)
+data ((f :: (Type -> Type) -> k -> Type) :++: (g :: (Type -> Type) -> k -> Type)) (q :: Type -> Type) (p :: k)
     = L2 (f q p)
     | R2 (g q p)
 
@@ -94,7 +94,7 @@ deriving instance (Show (f q p), Show (g q p)) => Show ((f :++: g) q p)
 deriving instance (Read (f q p), Read (g q p)) => Read ((f :++: g) q p)
 
 infixr 6 :**:
-data ((f :: z -> k -> Type) :**: (g :: z -> k -> Type)) (q :: z) (p :: k)
+data ((f :: (Type -> Type) -> k -> Type) :**: (g :: (Type -> Type) -> k -> Type)) (q :: Type -> Type) (p :: k)
     = f q p :**: g q p
 
 deriving instance (Eq (f q p), Eq (g q p)) => Eq ((f :**: g) q p)
@@ -104,7 +104,7 @@ deriving instance (Read (f q p), Read (g q p)) => Read ((f :**: g) q p)
 
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/15969#note_164233 !!!
 infixl 7 :@@:
-newtype ((f :: z -> k2 -> Type) :@@: (g :: k1 -> k2)) (q :: z) (p :: k1)
+newtype ((f :: (Type -> Type) -> k2 -> Type) :@@: (g :: k1 -> k2)) (q :: Type -> Type) (p :: k1)
     = App2 { unApp2 :: f q (g p) }
 
 deriving instance Eq (f q (g p)) => Eq ((f :@@: g) q p)

--- a/src/Staged/GHC/Generics/RepTypes.hs
+++ b/src/Staged/GHC/Generics/RepTypes.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+
+-- For default Rep definition
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_HADDOCK --not-home #-}
+module Staged.GHC.Generics.RepTypes (
+    -- * Generic representation types
+    V2,
+    U2 (..),
+    M2 (..),
+    K2 (..),
+    Par2 (..),
+    (:++:) (..),
+    (:**:) (..),
+    (:@@:) (..),
+    -- * Synonyms for convenience
+    D2, C2, S2,
+    D, C, S, R,
+    -- * Meta-information
+    Datatype (..),
+    Constructor (..),
+    Selector (..),
+    Fixity (..),
+    FixityI (..),
+    Associativity (..),
+    SourceUnpackedness (..),
+    SourceStrictness (..),
+    DecidedStrictness (..),
+    Meta (..),
+    -- * Rep translation
+    Translate,
+    -- * TH Types
+    Code, Quote
+) where
+
+import Data.Kind           (Type)
+import GHC.Generics
+       (Associativity (..), C, Constructor (..), D, Datatype (..),
+       DecidedStrictness (..), Fixity (..), FixityI (..), Meta (..), R, S,
+       Selector (..), SourceStrictness (..), SourceUnpackedness (..))
+import qualified GHC.Generics as GHC
+import Language.Haskell.TH (Code, Quote)
+import GHC.TypeLits        (ErrorMessage (..), TypeError)
+
+-------------------------------------------------------------------------------
+-- Combinators
+-------------------------------------------------------------------------------
+
+data V2 (q :: z) (p :: k)
+
+deriving instance Eq (V2 q p)
+deriving instance Ord (V2 q p)
+deriving instance Show (V2 q p)
+deriving instance Read (V2 q p)
+
+data U2 (q :: z) (p :: k) = U2
+
+deriving instance Eq (U2 q p)
+deriving instance Ord (U2 q p)
+deriving instance Show (U2 q p)
+deriving instance Read (U2 q p)
+
+newtype M2 (i :: Type) (c :: Meta) (f :: z -> k -> Type) (q :: z) (p :: k)
+    = M2 { unM2 :: f q p }
+
+deriving instance Eq (f q p) => Eq (M2 i c f q p)
+deriving instance Ord (f q p) => Ord (M2 i c f q p)
+deriving instance Show (f q p) => Show (M2 i c f q p)
+deriving instance Read (f q p) => Read (M2 i c f q p)
+
+newtype K2 c (q :: Type -> Type) (p :: k)
+    = K2 { unK2 :: q c }
+
+deriving instance Eq (q c) => Eq (K2 c q p)
+deriving instance Ord (q c) => Ord (K2 c q p)
+deriving instance Show (q c) => Show (K2 c q p)
+deriving instance Read (q c) => Read (K2 c q p)
+
+infixr 5 :++:
+data ((f :: z -> k -> Type) :++: (g :: z -> k -> Type)) (q :: z) (p :: k)
+    = L2 (f q p)
+    | R2 (g q p)
+
+deriving instance (Eq (f q p), Eq (g q p)) => Eq ((f :++: g) q p)
+deriving instance (Ord (f q p), Ord (g q p)) => Ord ((f :++: g) q p)
+deriving instance (Show (f q p), Show (g q p)) => Show ((f :++: g) q p)
+deriving instance (Read (f q p), Read (g q p)) => Read ((f :++: g) q p)
+
+infixr 6 :**:
+data ((f :: z -> k -> Type) :**: (g :: z -> k -> Type)) (q :: z) (p :: k)
+    = f q p :**: g q p
+
+deriving instance (Eq (f q p), Eq (g q p)) => Eq ((f :**: g) q p)
+deriving instance (Ord (f q p), Ord (g q p)) => Ord ((f :**: g) q p)
+deriving instance (Show (f q p), Show (g q p)) => Show ((f :**: g) q p)
+deriving instance (Read (f q p), Read (g q p)) => Read ((f :**: g) q p)
+
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/15969#note_164233 !!!
+infixl 7 :@@:
+newtype ((f :: z -> k2 -> Type) :@@: (g :: k1 -> k2)) (q :: z) (p :: k1)
+    = App2 { unApp2 :: f q (g p) }
+
+deriving instance Eq (f q (g p)) => Eq ((f :@@: g) q p)
+deriving instance Ord (f q (g p)) => Ord ((f :@@: g) q p)
+deriving instance Show (f q (g p)) => Show ((f :@@: g) q p)
+deriving instance Read (f q (g p)) => Read ((f :@@: g) q p)
+
+newtype Par2 (q :: k -> Type) (p :: k)
+    = Par2 { unPar2 :: q p }
+
+deriving instance Eq (q p) => Eq (Par2 q p)
+deriving instance Ord (q p) => Ord (Par2 q p)
+deriving instance Show (q p) => Show (Par2 q p)
+deriving instance Read (q p) => Read (Par2 q p)
+
+-------------------------------------------------------------------------------
+-- Synonyms for convenience
+-------------------------------------------------------------------------------
+
+type D2 = M2 D
+type C2 = M2 C
+type S2 = M2 S
+
+-- | Translate "GHC.Generics" 'GHC.Rep' type into our 'Rep' type.
+type family Translate (f :: k -> Type) :: (Type -> Type) -> k -> Type where
+    Translate (GHC.M1 i c f) = M2 i c (Translate f)
+    Translate (GHC.K1 R c)   = K2 c
+    Translate (f GHC.:+: g)  = Translate f :++: Translate g
+    Translate (f GHC.:*: g)  = Translate f :**: Translate g
+    Translate (GHC.Rec1 f)   = Par2 :@@: f
+    Translate GHC.Par1       = Par2
+    Translate GHC.U1         = U2
+    Translate GHC.V1         = V2
+    Translate (f GHC.:.: g)  = TranslateComp (Par2 :@@: f) g
+    Translate x              = TypeError ('Text "Translate error: " ':<>: 'ShowType x)
+
+type family TranslateComp (f :: (k -> Type) -> k1 -> Type) (g :: k2 -> k1) :: (Type -> Type) -> k -> Type where
+    TranslateComp acc (f GHC.:.: g) = TranslateComp (acc :@@: f) g
+    TranslateComp acc (GHC.Rec1 f)  = acc :@@: f
+    TranslateComp _   x             = TypeError ('Text "Translate :.: error: " ':<>: 'ShowType x)

--- a/src/Staged/GHC/Generics/Types.hs
+++ b/src/Staged/GHC/Generics/Types.hs
@@ -12,6 +12,10 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_HADDOCK --not-home #-}
+
+-- | This module contains the definitions of the 'Generic' and 'Generic1'
+-- classes. Caution: it does /not/ expose the instances! It is intended
+-- primarily for internal use.
 module Staged.GHC.Generics.Types (
     -- * Generic representation types
     V2,
@@ -39,6 +43,7 @@ module Staged.GHC.Generics.Types (
     -- * Generic type classes
     Generic (..),
     Generic1 (..),
+    GRep,
     genericTo,
     genericFrom,
     -- * TH Types
@@ -49,7 +54,7 @@ module Staged.GHC.Generics.Types (
 
 import Data.Kind           (Type)
 import Staged.GHC.Generics.RepTypes
-import Staged.GHC.Generics.GHCish (GGeneric (..), ghcGenericTo, ghcGenericFrom)
+import Staged.GHC.Generics.Generic (GGeneric, genericTo, genericFrom, GRep)
 
 import qualified GHC.Generics as GHC
 
@@ -59,27 +64,17 @@ import qualified GHC.Generics as GHC
 
 class Generic (a :: Type) where
     type Rep a :: (Type -> Type) -> Type -> Type
-    type Rep a = Translate (GHC.Rep a)
+    type Rep a = GRep a
 
     to   :: Quote q => Rep a (Code q) x -> Code q a
-    default to :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
+    default to :: (Rep a ~ GRep a, GHC.Generic a, GGeneric (Rep a), Quote q)
                => Rep a (Code q) x -> Code q a
     to = genericTo
 
     from :: Quote q => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
-    default from :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
+    default from :: (Rep a ~ GRep a, GHC.Generic a, GGeneric (Rep a), Quote q)
       => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
     from = genericFrom
-
--- | Use GHC generics to implement the 'to' method.
-genericTo :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
-  => Rep a (Code q) x -> Code q a
-genericTo = ghcGenericTo
-
--- | Use GHC generics to implement the 'from' method.
-genericFrom :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
-  => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
-genericFrom = ghcGenericFrom
 
 class Generic1 (f :: k -> Type) where
     type Rep1 f :: (Type -> Type) -> k -> Type

--- a/src/Staged/GHC/Generics/Types.hs
+++ b/src/Staged/GHC/Generics/Types.hs
@@ -57,21 +57,21 @@ import qualified GHC.Generics as GHC
 -- Combinators
 -------------------------------------------------------------------------------
 
-data V2 (q :: Type -> Type) (p :: k)
+data V2 (q :: z) (p :: k)
 
 deriving instance Eq (V2 q p)
 deriving instance Ord (V2 q p)
 deriving instance Show (V2 q p)
 deriving instance Read (V2 q p)
 
-data U2 (q :: Type -> Type) (p :: k) = U2
+data U2 (q :: z) (p :: k) = U2
 
 deriving instance Eq (U2 q p)
 deriving instance Ord (U2 q p)
 deriving instance Show (U2 q p)
 deriving instance Read (U2 q p)
 
-newtype M2 (i :: Type) (c :: Meta) (f :: (Type -> Type) -> k -> Type) (q :: Type -> Type) (p :: k)
+newtype M2 (i :: Type) (c :: Meta) (f :: z -> k -> Type) (q :: z) (p :: k)
     = M2 { unM2 :: f q p }
 
 deriving instance Eq (f q p) => Eq (M2 i c f q p)
@@ -88,7 +88,7 @@ deriving instance Show (q c) => Show (K2 c q p)
 deriving instance Read (q c) => Read (K2 c q p)
 
 infixr 5 :++:
-data ((f :: (Type -> Type) -> k -> Type) :++: (g :: (Type -> Type) -> k -> Type)) (q :: Type -> Type) (p :: k)
+data ((f :: z -> k -> Type) :++: (g :: z -> k -> Type)) (q :: z) (p :: k)
     = L2 (f q p)
     | R2 (g q p)
 
@@ -98,7 +98,7 @@ deriving instance (Show (f q p), Show (g q p)) => Show ((f :++: g) q p)
 deriving instance (Read (f q p), Read (g q p)) => Read ((f :++: g) q p)
 
 infixr 6 :**:
-data ((f :: (Type -> Type) -> k -> Type) :**: (g :: (Type -> Type) -> k -> Type)) (q :: Type -> Type) (p :: k)
+data ((f :: z -> k -> Type) :**: (g :: z -> k -> Type)) (q :: z) (p :: k)
     = f q p :**: g q p
 
 deriving instance (Eq (f q p), Eq (g q p)) => Eq ((f :**: g) q p)
@@ -108,7 +108,7 @@ deriving instance (Read (f q p), Read (g q p)) => Read ((f :**: g) q p)
 
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/15969#note_164233 !!!
 infixl 7 :@@:
-newtype ((f :: (Type -> Type) -> k2 -> Type) :@@: (g :: k1 -> k2)) (q :: Type -> Type) (p :: k1)
+newtype ((f :: z -> k2 -> Type) :@@: (g :: k1 -> k2)) (q :: z) (p :: k1)
     = App2 { unApp2 :: f q (g p) }
 
 deriving instance Eq (f q (g p)) => Eq ((f :@@: g) q p)
@@ -116,7 +116,7 @@ deriving instance Ord (f q (g p)) => Ord ((f :@@: g) q p)
 deriving instance Show (f q (g p)) => Show ((f :@@: g) q p)
 deriving instance Read (f q (g p)) => Read ((f :@@: g) q p)
 
-newtype Par2 (q :: Type -> Type) (p :: Type)
+newtype Par2 (q :: k -> Type) (p :: k)
     = Par2 { unPar2 :: q p }
 
 deriving instance Eq (q p) => Eq (Par2 q p)

--- a/src/Staged/GHC/Generics/Types.hs
+++ b/src/Staged/GHC/Generics/Types.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DefaultSignatures    #-}
+{-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
@@ -37,6 +39,8 @@ module Staged.GHC.Generics.Types (
     -- * Generic type classes
     Generic (..),
     Generic1 (..),
+    genericTo,
+    genericFrom,
     -- * TH Types
     Code, Quote,
     -- * Utilities
@@ -44,93 +48,10 @@ module Staged.GHC.Generics.Types (
 ) where
 
 import Data.Kind           (Type)
-import GHC.Generics
-       (Associativity (..), C, Constructor (..), D, Datatype (..),
-       DecidedStrictness (..), Fixity (..), FixityI (..), Meta (..), R, S,
-       Selector (..), SourceStrictness (..), SourceUnpackedness (..))
-import GHC.TypeLits        (ErrorMessage (..), TypeError)
-import Language.Haskell.TH (Code, Quote)
+import Staged.GHC.Generics.RepTypes
+import Staged.GHC.Generics.GHCish (GGeneric (..), ghcGenericTo, ghcGenericFrom)
 
 import qualified GHC.Generics as GHC
-
--------------------------------------------------------------------------------
--- Combinators
--------------------------------------------------------------------------------
-
-data V2 (q :: z) (p :: k)
-
-deriving instance Eq (V2 q p)
-deriving instance Ord (V2 q p)
-deriving instance Show (V2 q p)
-deriving instance Read (V2 q p)
-
-data U2 (q :: z) (p :: k) = U2
-
-deriving instance Eq (U2 q p)
-deriving instance Ord (U2 q p)
-deriving instance Show (U2 q p)
-deriving instance Read (U2 q p)
-
-newtype M2 (i :: Type) (c :: Meta) (f :: z -> k -> Type) (q :: z) (p :: k)
-    = M2 { unM2 :: f q p }
-
-deriving instance Eq (f q p) => Eq (M2 i c f q p)
-deriving instance Ord (f q p) => Ord (M2 i c f q p)
-deriving instance Show (f q p) => Show (M2 i c f q p)
-deriving instance Read (f q p) => Read (M2 i c f q p)
-
-newtype K2 c (q :: Type -> Type) (p :: k)
-    = K2 { unK2 :: q c }
-
-deriving instance Eq (q c) => Eq (K2 c q p)
-deriving instance Ord (q c) => Ord (K2 c q p)
-deriving instance Show (q c) => Show (K2 c q p)
-deriving instance Read (q c) => Read (K2 c q p)
-
-infixr 5 :++:
-data ((f :: z -> k -> Type) :++: (g :: z -> k -> Type)) (q :: z) (p :: k)
-    = L2 (f q p)
-    | R2 (g q p)
-
-deriving instance (Eq (f q p), Eq (g q p)) => Eq ((f :++: g) q p)
-deriving instance (Ord (f q p), Ord (g q p)) => Ord ((f :++: g) q p)
-deriving instance (Show (f q p), Show (g q p)) => Show ((f :++: g) q p)
-deriving instance (Read (f q p), Read (g q p)) => Read ((f :++: g) q p)
-
-infixr 6 :**:
-data ((f :: z -> k -> Type) :**: (g :: z -> k -> Type)) (q :: z) (p :: k)
-    = f q p :**: g q p
-
-deriving instance (Eq (f q p), Eq (g q p)) => Eq ((f :**: g) q p)
-deriving instance (Ord (f q p), Ord (g q p)) => Ord ((f :**: g) q p)
-deriving instance (Show (f q p), Show (g q p)) => Show ((f :**: g) q p)
-deriving instance (Read (f q p), Read (g q p)) => Read ((f :**: g) q p)
-
--- https://gitlab.haskell.org/ghc/ghc/-/issues/15969#note_164233 !!!
-infixl 7 :@@:
-newtype ((f :: z -> k2 -> Type) :@@: (g :: k1 -> k2)) (q :: z) (p :: k1)
-    = App2 { unApp2 :: f q (g p) }
-
-deriving instance Eq (f q (g p)) => Eq ((f :@@: g) q p)
-deriving instance Ord (f q (g p)) => Ord ((f :@@: g) q p)
-deriving instance Show (f q (g p)) => Show ((f :@@: g) q p)
-deriving instance Read (f q (g p)) => Read ((f :@@: g) q p)
-
-newtype Par2 (q :: k -> Type) (p :: k)
-    = Par2 { unPar2 :: q p }
-
-deriving instance Eq (q p) => Eq (Par2 q p)
-deriving instance Ord (q p) => Ord (Par2 q p)
-deriving instance Show (q p) => Show (Par2 q p)
-deriving instance Read (q p) => Read (Par2 q p)
-
--------------------------------------------------------------------------------
--- Synonyms for convenience
--------------------------------------------------------------------------------
-
-type D2 = M2 D
-type C2 = M2 C
-type S2 = M2 S
 
 -------------------------------------------------------------------------------
 -- Generic type class
@@ -141,7 +62,24 @@ class Generic (a :: Type) where
     type Rep a = Translate (GHC.Rep a)
 
     to   :: Quote q => Rep a (Code q) x -> Code q a
+    default to :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
+               => Rep a (Code q) x -> Code q a
+    to = genericTo
+
     from :: Quote q => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
+    default from :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
+      => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
+    from = genericFrom
+
+-- | Use GHC generics to implement the 'to' method.
+genericTo :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
+  => Rep a (Code q) x -> Code q a
+genericTo = ghcGenericTo
+
+-- | Use GHC generics to implement the 'from' method.
+genericFrom :: (Rep a ~ Translate (GHC.Rep a), GHC.Generic a, GGeneric (Rep a), Quote q)
+  => Code q a -> (Rep a (Code q) x -> Code q r) -> Code q r
+genericFrom = ghcGenericFrom
 
 class Generic1 (f :: k -> Type) where
     type Rep1 f :: (Type -> Type) -> k -> Type
@@ -149,28 +87,6 @@ class Generic1 (f :: k -> Type) where
 
     to1   :: Quote q => Rep1 f (Code q) x -> Code q (f x)
     from1 :: Quote q => Code q (f x) -> (Rep1 f (Code q) x -> Code q r) -> Code q r
-
--------------------------------------------------------------------------------
--- Derive our Rep from GHC.Generics.Rep
--------------------------------------------------------------------------------
-
--- | Translate "GHC.Generics" 'GHC.Rep' type into our 'Rep' type.
-type family Translate (f :: k -> Type) :: (Type -> Type) -> k -> Type where
-    Translate (GHC.M1 i c f) = M2 i c (Translate f)
-    Translate (GHC.K1 R c)   = K2 c
-    Translate (f GHC.:+: g)  = Translate f :++: Translate g
-    Translate (f GHC.:*: g)  = Translate f :**: Translate g
-    Translate (GHC.Rec1 f)   = Par2 :@@: f
-    Translate GHC.Par1       = Par2
-    Translate GHC.U1         = U2
-    Translate GHC.V1         = V2
-    Translate (f GHC.:.: g)  = TranslateComp (Par2 :@@: f) g
-    Translate x              = TypeError ('Text "Translate error: " ':<>: 'ShowType x)
-
-type family TranslateComp (f :: (k -> Type) -> k1 -> Type) (g :: k2 -> k1) :: (Type -> Type) -> k -> Type where
-    TranslateComp acc (f GHC.:.: g) = TranslateComp (acc :@@: f) g
-    TranslateComp acc (GHC.Rec1 f)  = acc :@@: f
-    TranslateComp _   x             = TypeError ('Text "Translate :.: error: " ':<>: 'ShowType x)
 
 -------------------------------------------------------------------------------
 -- Example instance(s)

--- a/staged-gg-examples/src/Staged/GHC/Generics/Examples/Foo.hs
+++ b/staged-gg-examples/src/Staged/GHC/Generics/Examples/Foo.hs
@@ -9,15 +9,12 @@ module Staged.GHC.Generics.Examples.Foo where
 import qualified GHC.Generics as GHC
 
 import Staged.GHC.Generics
-import Staged.GHC.Generics.GHCish
 
 -- | Example product type.
 data Foo = Foo [Int] Ordering String
   deriving (GHC.Generic)
 
-instance Generic Foo where
-    to   = ghcGenericTo
-    from = ghcGenericFrom
+instance Generic Foo
 
 data Bar f a = Bar (f a)
   deriving (GHC.Generic, GHC.Generic1)

--- a/staged-gg-examples/src/Staged/GHC/Generics/Examples/Foo.hs
+++ b/staged-gg-examples/src/Staged/GHC/Generics/Examples/Foo.hs
@@ -9,12 +9,15 @@ module Staged.GHC.Generics.Examples.Foo where
 import qualified GHC.Generics as GHC
 
 import Staged.GHC.Generics
+import Staged.GHC.Generics.GHCish
 
 -- | Example product type.
 data Foo = Foo [Int] Ordering String
   deriving (GHC.Generic)
 
-$(deriveGeneric ''Foo)
+instance Generic Foo where
+    to   = ghcGenericTo
+    from = ghcGenericFrom
 
 data Bar f a = Bar (f a)
   deriving (GHC.Generic, GHC.Generic1)

--- a/staged-gg.cabal
+++ b/staged-gg.cabal
@@ -52,10 +52,10 @@ library
     Staged.GHC.Generics.TH
     Staged.GHC.Generics.Types
     Staged.GHC.Generics.RepTypes
+    Staged.GHC.Generics.Generic
 
   other-modules:
     Generics.Deriving.TH.Internal
     Generics.Deriving.TH.Post4_9
     Staged.GHC.Generics.Internal
     Staged.GHC.Generics.TH.Names
-    Staged.GHC.Generics.GHCish

--- a/staged-gg.cabal
+++ b/staged-gg.cabal
@@ -51,10 +51,11 @@ library
     Staged.GHC.Generics.Instances
     Staged.GHC.Generics.TH
     Staged.GHC.Generics.Types
-    Staged.GHC.Generics.GHCish
+    Staged.GHC.Generics.RepTypes
 
   other-modules:
     Generics.Deriving.TH.Internal
     Generics.Deriving.TH.Post4_9
     Staged.GHC.Generics.Internal
     Staged.GHC.Generics.TH.Names
+    Staged.GHC.Generics.GHCish

--- a/staged-gg.cabal
+++ b/staged-gg.cabal
@@ -51,6 +51,7 @@ library
     Staged.GHC.Generics.Instances
     Staged.GHC.Generics.TH
     Staged.GHC.Generics.Types
+    Staged.GHC.Generics.GHCish
 
   other-modules:
     Generics.Deriving.TH.Internal


### PR DESCRIPTION
Add functions `genericTo` and `genericFrom` that use GHC
Generics to implement the `Generic` methods.